### PR TITLE
Changes to be able to use the chart as subchart

### DIFF
--- a/metacontroller/Chart.yaml
+++ b/metacontroller/Chart.yaml
@@ -2,7 +2,7 @@ name: metacontroller
 apiVersion: v1
 appVersion: "v0.4.0"
 description: A Helm chart for Metacontroller
-version: 1.1.0
+version: 1.1.1
 home: https://metacontroller.app/
 keywords:
 - CRDs

--- a/metacontroller/templates/crd-cleanup-job.yaml
+++ b/metacontroller/templates/crd-cleanup-job.yaml
@@ -19,9 +19,6 @@ spec:
         app: {{ template "metacontroller.fullname" . }}-crd-cleanup
 {{ include "metacontroller.labels" . | indent 8 }}
     spec:
-    {{- if .Values.rbac.create }}
-      serviceAccountName: {{ template "metacontroller.serviceAccountName" . }}
-    {{- end }}
       containers:
         - name: kubectl
           image: "{{ .Values.hyperkubeImage.repository }}:{{ .Values.hyperkubeImage.tag }}"

--- a/metacontroller/templates/crds.yaml
+++ b/metacontroller/templates/crds.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: compositecontrollers.metacontroller.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: metacontroller.k8s.io
   version: v1alpha1
@@ -19,6 +21,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: decoratorcontrollers.metacontroller.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: metacontroller.k8s.io
   version: v1alpha1
@@ -35,6 +39,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: controllerrevisions.metacontroller.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: metacontroller.k8s.io
   version: v1alpha1


### PR DESCRIPTION
I wanted to use the metacontroller helm chart as a subchart for an operator I created
However, I ran into trouble because my helm chart of course defines an object for a CRD posted by the metacontroller chart and helm tries to bundle everything in one call.
This PR fixes that by annotating the CRDs with the helm.sh `crd-install` hook annotation (see https://helm.sh/docs/chart_best_practices/#custom-resource-definitions).
The drawback is that, when deleting the release, the crd's are not automatically cleaned up. But this chart has a nice post-delete job that takes care of that. 
There was only one small problem with that job: if during installation a service account is created, the post-delete job uses that serviceaccount. However, when it runs, that account is already deleted from k8s. This PR also fixes that: the post-delete job is not using that created service account
